### PR TITLE
19 add package specific css selectors

### DIFF
--- a/packages/audio-player-ui/src/components/player-content/controls/PlayToggle/PlayToggle.tsx
+++ b/packages/audio-player-ui/src/components/player-content/controls/PlayToggle/PlayToggle.tsx
@@ -11,15 +11,15 @@ export const PlayToggle = ({ pausePlayHandler, playing }: PlayToggleProps) => {
     <>
       <button
         onClick={pausePlayHandler}
-        className={!playing ? "inline-block" : "hidden"}
+        className={`pa-audio-player__play-button ${!playing ? "inline-block" : "hidden"}`}
       >
-        <GrPlayFill className="w-6 h-6" />
+        <GrPlayFill className="pa-audio-player__play-icon w-6 h-6" />
       </button>
       <button
         onClick={pausePlayHandler}
-        className={playing ? "inline-block" : "hidden"}
+        className={`pa-audio-player__pause-button ${playing ? "inline-block" : "hidden"}`}
       >
-        <GrPauseFill className="w-6 h-6" />
+        <GrPauseFill className="pa-audio-player__pause-icon w-6 h-6" />
       </button>
     </>
   );

--- a/packages/audio-player-ui/src/components/player-content/controls/PrevNext/Next.tsx
+++ b/packages/audio-player-ui/src/components/player-content/controls/PrevNext/Next.tsx
@@ -7,8 +7,8 @@ export const Next = ({ nextSong }: any) => {
     return null;
   }
   return (
-    <button onClick={nextSong}>
-      <BiSkipNext className="w-6 h-6" />
+    <button onClick={nextSong} className="pa-audio-player__next">
+      <BiSkipNext className="pa-audio-player__next-icon w-6 h-6" />
     </button>
   );
 };

--- a/packages/audio-player-ui/src/components/player-content/controls/PrevNext/Prev.tsx
+++ b/packages/audio-player-ui/src/components/player-content/controls/PrevNext/Prev.tsx
@@ -7,8 +7,8 @@ export const Prev = ({ prevSong }: any) => {
     return null;
   }
   return (
-    <button onClick={prevSong}>
-      <BiSkipPrevious className="w-6 h-6" />
+    <button onClick={prevSong} className="pa-audio-player__prev">
+      <BiSkipPrevious className="pa-audio-player__prev-icon w-6 h-6" />
     </button>
   );
 };

--- a/packages/audio-player-ui/src/components/player-content/controls/ProgressBar/ProgressBar.tsx
+++ b/packages/audio-player-ui/src/components/player-content/controls/ProgressBar/ProgressBar.tsx
@@ -18,16 +18,16 @@ export const ProgressBar = ({
   };
 
   return (
-    <span className="w-full px-6 flex items-center gap-4 ">
+    <span className="pa-audio-player__progress-wrapper w-full px-6 flex items-center gap-4">
       <input
         type="range"
-        className="w-[100%] cursor-pointer"
+        className="pa-audio-player__progress-range w-[100%] cursor-pointer"
         min="0"
         value={progress}
         max={Math.floor(duration)}
         onChange={(e: any) => handleProgress(e as any)}
       />
-      <span className=" tabular-nums">{timeLeft()}</span>
+      <span className="pa-audio-player__progress-time-left tabular-nums">{timeLeft()}</span>
     </span>
   );
 };

--- a/packages/audio-player-ui/src/components/player-content/controls/VolControls/VolControls.tsx
+++ b/packages/audio-player-ui/src/components/player-content/controls/VolControls/VolControls.tsx
@@ -9,17 +9,17 @@ export const VolControls = ({ isMuted, toggleMute }: VolControlsProps) => {
     <>
       <button
         onClick={() => toggleMute()}
-        className={`${!isMuted ? "inline-block" : "hidden"}`}
+        className={`pa-audio-player__volume-controls-volume ${!isMuted ? "inline-block" : "hidden"}`}
         aria-label="volume"
       >
-        <ImVolumeMedium className="w-6 h-6" />
+        <ImVolumeMedium className="pa-audio-player__volume-controls-volume-icon w-6 h-6" />
       </button>
       <button
         onClick={toggleMute}
-        className={isMuted ? "inline-block" : "hidden"}
+        className={`pa-audio-player__volume-controls-muted ${isMuted ? "inline-block" : "hidden"}`}
         aria-label="muted"
       >
-        <ImVolumeMute className="w-6 h-6" />
+        <ImVolumeMute className="pa-audio-player__volume-controls-muted-icon w-6 h-6" />
       </button>
     </>
   );

--- a/packages/audio-player-ui/src/components/player-content/controls/VolSlider/VolSlider.tsx
+++ b/packages/audio-player-ui/src/components/player-content/controls/VolSlider/VolSlider.tsx
@@ -12,7 +12,7 @@ export const VolSlider = ({ volume, handleVolume }: VolControlsProps) => {
       max={1}
       step={0.01}
       value={volume}
-      className="cursor-pointer w-20 hidden sm:block"
+      className="pa-audio-player__volume-slider cursor-pointer w-20 hidden sm:block"
       onChange={(e) => handleVolume(e as any)}
     />
   );

--- a/packages/audio-player-ui/src/components/player-content/wrappers/InfoContainer/InfoContainer.tsx
+++ b/packages/audio-player-ui/src/components/player-content/wrappers/InfoContainer/InfoContainer.tsx
@@ -4,11 +4,11 @@ export const AudioPlayerDisplayInfo = ({}) => {
   const { currentTrack } = usePlayerContext();
   const { artist, title } = currentTrack;
   return (
-    <div className="col-span-2 ">
-      <div className="flex items-center">
-        <span className="">{artist}</span>
-        <span className="mx-1">-</span>
-        <span className="truncate">{title}</span>
+    <div className="pa-audio-player__info-container col-span-2 ">
+      <div className="pa-audio-player__info-container-items flex items-center">
+        <span className="pa-audio-player__info-container-artist">{artist}</span>
+        <span className="pa-audio-player__info-container-hyphen mx-1">-</span>
+        <span className="pa-audio-player__info-container-title truncate">{title}</span>
       </div>
     </div>
   );

--- a/packages/audio-player-ui/src/components/player-content/wrappers/PlayerWrapper/PlayerWrapper.tsx
+++ b/packages/audio-player-ui/src/components/player-content/wrappers/PlayerWrapper/PlayerWrapper.tsx
@@ -4,8 +4,8 @@ export function PlayerWrapper({
   children?: JSX.Element | JSX.Element[];
 }) {
   return (
-    <div className="flex items-center z-40 fixed bottom-0  left-0 right-0 justify-between  ">
-      <div className="flex flex-col gap-2 xl:grid grid-cols-12 w-[100%] bg-[#ffffff] text-sm text-stone-800 border-t border-t-stone-300 border-l-0 border-b-0 border-r-0  p-6 ">
+    <div className="pa-audio-player__player flex items-center z-40 fixed bottom-0  left-0 right-0 justify-between  ">
+      <div className="pa-audio-player__player-wrapper flex flex-col gap-2 xl:grid grid-cols-12 w-[100%] bg-[#ffffff] text-sm text-stone-800 border-t border-t-stone-300 border-l-0 border-b-0 border-r-0  p-6 ">
         {children}
       </div>
     </div>

--- a/packages/audio-player-ui/src/components/player-content/wrappers/controls-wrapper/ControlsContainer.tsx
+++ b/packages/audio-player-ui/src/components/player-content/wrappers/controls-wrapper/ControlsContainer.tsx
@@ -23,9 +23,9 @@ export const ControlsContainer = () => {
     handleVolume,
   } = usePlayerContext();
   return (
-    <div className="col-span-6 lg:col-span-10">
-      <div className="flex justify-between items-center w-[100%]">
-        <div className="flex items-center gap-2">
+    <div className="pa-audio-player__controls col-span-6 lg:col-span-10">
+      <div className="pa-audio-player__controls-wrapper flex justify-between items-center w-[100%]">
+        <div className="pa-audio-player__controls-play-pause-prev-next flex items-center gap-2">
           <Prev prevSong={prevSong} />
           <PlayToggle
             pausePlayHandler={pausePlayHandler}


### PR DESCRIPTION
@Javier-Szyfer @0xTranqui just realized another important addition would be the addition of selectors so user can target each component from a custom stylesheet. Wouldn't need to attach any styling to them.

We could just establish a general pattern where the universal prefix is: 

`pa-[package-name]__`

ie: `pa-audioplayer__`

Example usage:

```
export const PlayToggle = ({ pausePlayHandler, playing }: PlayToggleProps) => {
  return (
    <>
      <button
        onClick={pausePlayHandler}
        className={`pa-audioplayer__play-button ${!playing ? "inline-block" : "hidden"}`}
      >
        <GrPlayFill className="pa-audioplayer__play-icon w-6 h-6" />
      </button>
      <button
        onClick={pausePlayHandler}
        className={`pa-audioplayer__pause-button ${playing ? "inline-block" : "hidden"}`}
      >
        <GrPauseFill className="pa-audioplayer__pause-icon w-6 h-6" />
      </button>
    </>
  );
};
```