### PR TITLE
30 add ens name resolution for creator addresses

### DIFF
--- a/.changeset/cool-clouds-tell.md
+++ b/.changeset/cool-clouds-tell.md
@@ -1,0 +1,5 @@
+---
+'@public-assembly/audio-player-ui': minor
+---
+
+Integrate zora drops utils

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "clean": "rimraf --no-glob .next node_modules"
   },
   "dependencies": {
     "@public-assembly/zora-drops-utils": "^0.0.6",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "dev": "parcel src/index.html"
+    "dev": "parcel src/index.html",
+    "clean": "rimraf --no-glob dist node_modules"
   },
   "dependencies": {
     "@public-assembly/zora-drops-utils": "^0.0.3",

--- a/packages/audio-player-ui/package.json
+++ b/packages/audio-player-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@public-assembly/audio-player-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Audio player package",
   "main": "dist/public-assembly-audio-player-ui.cjs.js",
   "module": "dist/public-assembly-audio-player-ui.esm.js",
@@ -18,7 +18,8 @@
     "@public-assembly/zora-drops-utils": "^0.0.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-icons": "4.4.0"
+    "react-icons": "4.4.0",
+    "wagmi": "^0.6.7"
   },
   "devDependencies": {
     "react": "^18.2.0",

--- a/packages/audio-player-ui/package.json
+++ b/packages/audio-player-ui/package.json
@@ -16,6 +16,7 @@
   ],
   "peerDependencies": {
     "@public-assembly/zora-drops-utils": "^0.0.6",
+    "ethers": "^5.7.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "4.4.0",

--- a/packages/audio-player-ui/src/components/wrappers/InfoContainer.tsx
+++ b/packages/audio-player-ui/src/components/wrappers/InfoContainer.tsx
@@ -2,20 +2,30 @@
 import * as React from 'react'
 import { useEnsName } from 'wagmi'
 import { usePlayerContext } from '../../context/AudioPlayerContext'
+import { useValidAddress } from '../../hooks/useValidAddress'
+import { shortenAddress } from '../../lib'
 
 export const AudioPlayerDisplayInfo = () => {
   const { currentTrack } = usePlayerContext()
+
+  const isValidAddress = useValidAddress(currentTrack?.artist)
 
   const { data: ensName } = useEnsName({
     address: currentTrack?.artist,
   })
 
+  const artistName = React.useMemo(() => {
+    if (!isValidAddress) {
+      return currentTrack?.artist
+    } else {
+      return ensName ? ensName : shortenAddress(currentTrack?.artist)
+    }
+  }, [isValidAddress, ensName, currentTrack?.artist])
+
   return (
     <div className="pa-audio-player__info-container col-span-2 ">
       <div className="pa-audio-player__info-container-items flex items-center">
-        <span className="pa-audio-player__info-container-artist">
-          {ensName ? ensName : currentTrack?.artist}
-        </span>
+        <span className="pa-audio-player__info-container-artist">{artistName}</span>
         <span className="pa-audio-player__info-container-hyphen mx-1">-</span>
         <span className="pa-audio-player__info-container-title truncate">
           {currentTrack?.title}

--- a/packages/audio-player-ui/src/components/wrappers/InfoContainer.tsx
+++ b/packages/audio-player-ui/src/components/wrappers/InfoContainer.tsx
@@ -1,15 +1,20 @@
 // @ts-ignore:next-line
 import * as React from 'react'
-
+import { useEnsName } from 'wagmi'
 import { usePlayerContext } from '../../context/AudioPlayerContext'
 
-export const AudioPlayerDisplayInfo = ({}) => {
+export const AudioPlayerDisplayInfo = () => {
   const { currentTrack } = usePlayerContext()
+
+  const { data: ensName } = useEnsName({
+    address: currentTrack?.artist,
+  })
+
   return (
     <div className="pa-audio-player__info-container col-span-2 ">
       <div className="pa-audio-player__info-container-items flex items-center">
         <span className="pa-audio-player__info-container-artist">
-          {currentTrack?.artist}
+          {ensName ? ensName : currentTrack?.artist}
         </span>
         <span className="pa-audio-player__info-container-hyphen mx-1">-</span>
         <span className="pa-audio-player__info-container-title truncate">

--- a/packages/audio-player-ui/src/hooks/useValidAddress.ts
+++ b/packages/audio-player-ui/src/hooks/useValidAddress.ts
@@ -1,0 +1,10 @@
+import React from 'react'
+import { isAddress } from 'ethers/lib/utils'
+
+export function useValidAddress(collectionAddress: string) {
+  const isValidAddress = React.useMemo(
+    () => isAddress(collectionAddress as string),
+    [collectionAddress]
+  )
+  return isValidAddress
+}

--- a/packages/audio-player-ui/src/lib/index.ts
+++ b/packages/audio-player-ui/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './shortenAddress'

--- a/packages/audio-player-ui/src/lib/shortenAddress.ts
+++ b/packages/audio-player-ui/src/lib/shortenAddress.ts
@@ -1,0 +1,22 @@
+import { getAddress } from 'ethers/lib/utils'
+
+export function isAddress(value: any): string | false {
+  try {
+    return getAddress(value)
+  } catch {
+    return false
+  }
+}
+
+export function shortenAddress(address?: string, chars = 4): string {
+  if (!address) {
+    return ''
+  }
+
+  const parsed = isAddress(address)
+  if (!parsed) {
+    console.error(`Invalid 'address' parameter '${address}'.`)
+    return ''
+  }
+  return `${parsed.substring(0, chars)}...${parsed.substring(42 - chars)}`
+}


### PR DESCRIPTION
This PR adds ens resolution via wagmi and an address trucation via ethers.js

Peer deps introduced:
- wagmi
- ethers.js

@Javier-Szyfer whenever you jump back in this you'll need to update all your dependencies.
there is a new `yarn clean` command that removes all the node_modules and cache folders.

Run that and then run a fresh `yarn install`

<img width="1208" alt="Screen Shot 2022-09-28 at 5 40 38 PM" src="https://user-images.githubusercontent.com/7268786/192913032-7703d351-9a44-49a0-9d0b-3d6ccc24e889.png">

<img width="606" alt="Screen Shot 2022-09-28 at 5 40 20 PM" src="https://user-images.githubusercontent.com/7268786/192913041-4ebe7199-1c64-4ca5-bf46-4987a9093919.png">
